### PR TITLE
Ajout d'un type de prescription manquant pour SCOT

### DIFF
--- a/server/utils/enrichProcedures.js
+++ b/server/utils/enrichProcedures.js
@@ -18,6 +18,7 @@ const eventsCategs = {
     "Délibération de prescription du conseil municipal ou communautaire",
     "Délibération de prescription du conseil municipal",
     "Delibération de l'établissement public", "Délibération de l'Etablissement Public", // SCOT
+    "Délibération de l'établissement public qui prescrit", // SCOT
     'Publication de périmètre', 'Publication périmètre' // SCOT
   ],
   publicationPerim: ['Publication de périmètre', 'Publication périmètre'],


### PR DESCRIPTION
Il manque la prescription dans la liste des events de prescription avec le nouveau nom d'event.

Ce n'était pas qu'une question d'ordre, l'event de prescription n'était pas trouvé.