### PR TITLE
Pour chaque type d'événement, seul le plus récent compte

### DIFF
--- a/server/utils/enrichProcedures.js
+++ b/server/utils/enrichProcedures.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs'
 
 function sortEvents(events) {
   return events.sort((a, b) => {
-    return +dayjs(a.date_iso) - +dayjs(b.date_iso)
+    return +dayjs(b.date_iso) - +dayjs(a.date_iso)
   })
 }
 

--- a/server/utils/fetchCommunesProcedures.js
+++ b/server/utils/fetchCommunesProcedures.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs'
 
 function sortEvents(events) {
   return events.sort((a, b) => {
-    return a.timestamp - b.timestamp
+    return b.timestamp - a.timestamp
   })
 }
 

--- a/server/utils/fetchProceduresChunk.js
+++ b/server/utils/fetchProceduresChunk.js
@@ -2,7 +2,7 @@ import dayjs from 'dayjs'
 
 function sortEvents(events) {
   return events.sort((a, b) => {
-    return +dayjs(a.date_iso) - +dayjs(b.date_iso)
+    return +dayjs(b.date_iso) - +dayjs(a.date_iso)
   })
 }
 


### PR DESCRIPTION
A priori il n'y a pas besoins de faire plus. Dans mes test je retrouve bien les bonne date de prescription et d'approbations. Ce changement impactera aussi la mise a jour quotidienne avec Sudocuh et devrait permetre de corrigé les cas de mauvaise procédure opposable remonté par Célia.

ref https://github.com/MTES-MCT/Docurba/issues/1115