### PR TITLE
Rustine : Améliore l'opposabilité des PLU au détriment des CC

### DIFF
--- a/server/utils/enrichProcedures.js
+++ b/server/utils/enrichProcedures.js
@@ -8,7 +8,7 @@ function sortEvents(events) {
 }
 
 const eventsCategs = {
-  approbation: ["Délibération d'approbation", "Arrêté d'abrogation", "Arrêté du Maire ou du Préfet ou de l'EPCI", 'Approbation du préfet'],
+  approbation: ["Délibération d'approbation", "Arrêté d'abrogation", "Arrêté du Maire ou du Préfet ou de l'EPCI", 'Approbation du préfet', "Délibération d'approbation du conseil municipal ou communautaire"],
   arret: ['Arrêt de projet'],
   pac: ['Porter à connaissance'],
   deliberation: ["Délibération de l'Etab Pub sur les modalités de concertation", "Délibération de l'Etablissement Public"],


### PR DESCRIPTION
Ajoute "Délibération d'approbation du conseil municipal ou communautaire" à la liste des événements affectant la date d'approbation.

Sans cet événement dans cette liste, des PLU approuvés apparaissent "Précédent" car ils sont considérés "Approuvés" mais avec une date d'approbation au 0000-00-00.

Pour les CC, cet événement ne vaut pas approbation et il est donc gênant de l'ajouter ici. Mais comme on détermine le statut "Approuvé" d'une procédure dans la fonction SQL [`get_event_impact`][] qui utilise des listes séparées, la gêne devrait être minime : la carte communale aura une date d'approbation un peu plus tôt que la réalité mais elle ne sera pas considérée approuvée par erreur.

Le correctif plus complet nécessite de maintenir des listes distinctes par type de document, ce qui est fait dans Django et sera effectif sur le site via https://github.com/MTES-MCT/Docurba/issues/1254.

[`get_event_impact`]: https://github.com/MTES-MCT/Docurba/blob/0a7bcadbc7a75294d7cef7f801e8a993debc64ae/nuxt/daily_dump/steps/sql/status_handler/1-get_event_impact.sql