### PR TITLE
Scalingo : ajout du manifeste scalingo.json pour la création de recettes jetables

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,7 @@
+{
+    "env": {
+        "APP_URL": {
+            "generator": "url"
+        }
+    }
+}

--- a/scalingo.json
+++ b/scalingo.json
@@ -3,5 +3,11 @@
         "APP_URL": {
             "generator": "url"
         }
+    },
+    "formation": {
+        "web": {
+            "amount": 1,
+            "size": "S"
+        }
     }
 }


### PR DESCRIPTION
Permet de récupérer l'URL générée et de la passer à l'application Nuxt 2 dans un environnement de recette jetable.
Permet également de ne provisionner qu'un conteneur S (alors que la valeur par défaut semble être du M).
Voir https://github.com/MTES-MCT/Docurba/pull/1535