### PR TITLE
Scalingo : augmentation du plan pour les recettes jetables

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -7,7 +7,7 @@
     "formation": {
         "web": {
             "amount": 1,
-            "size": "S"
+            "size": "M"
         }
     }
 }


### PR DESCRIPTION
En-dessous du plan M, le build ne passe pas.

ref https://github.com/MTES-MCT/Docurba/issues/1486
